### PR TITLE
Rename Excute methods to Execute

### DIFF
--- a/Excely.ClosedXML/Shaders/CellFittingShader.cs
+++ b/Excely.ClosedXML/Shaders/CellFittingShader.cs
@@ -10,7 +10,7 @@ namespace Excely.ClosedXML.Shaders
         public double MinWidth { get; set; } = 1;
         public double MaxWidth { get; set; } = 50;
 
-        protected override void ExcuteOnWorksheet(IXLWorksheet worksheet)
+        protected override void ExecuteOnWorksheet(IXLWorksheet worksheet)
         {
             worksheet.Columns().AdjustToContents(MinWidth, MaxWidth);
             worksheet.Columns().Style.Alignment.WrapText = true;

--- a/Excely.ClosedXML/Shaders/ErrorMarkShader.cs
+++ b/Excely.ClosedXML/Shaders/ErrorMarkShader.cs
@@ -25,7 +25,7 @@ namespace Excely.ClosedXML.Shaders
 			CellErrors = errorCells ?? new();
 		}
 
-		protected override void ExcuteOnWorksheet(IXLWorksheet worksheet)
+		protected override void ExecuteOnWorksheet(IXLWorksheet worksheet)
 		{
 			foreach (var cellError in CellErrors)
 			{

--- a/Excely.ClosedXML/Shaders/SchemaFilterShader.cs
+++ b/Excely.ClosedXML/Shaders/SchemaFilterShader.cs
@@ -27,7 +27,7 @@ namespace Excely.ClosedXML.Shaders
             StartCell = startCell;
         }
 
-        protected override void ExcuteOnWorksheet(IXLWorksheet target)
+        protected override void ExecuteOnWorksheet(IXLWorksheet target)
         {
             var schemaLength = SchemaLength;
             if (SchemaLength == 0)

--- a/Excely.ClosedXML/Shaders/TableThemeShader.cs
+++ b/Excely.ClosedXML/Shaders/TableThemeShader.cs
@@ -43,7 +43,7 @@ namespace Excely.ClosedXML.Shaders
             TableHeight = tableHeight;
         }
 
-        protected override void ExcuteOnWorksheet(IXLWorksheet worksheet)
+        protected override void ExecuteOnWorksheet(IXLWorksheet worksheet)
         {
             var tableWidth = TableWidth;
             if (TableWidth == 0)

--- a/Excely.ClosedXML/Shaders/XlsxShaderBase.cs
+++ b/Excely.ClosedXML/Shaders/XlsxShaderBase.cs
@@ -8,17 +8,17 @@ namespace Excely.ClosedXML.Shaders
     /// </summary>
     public abstract class XlsxShaderBase : IShader
     {
-        public T Excute<T>(T target)
+        public T Execute<T>(T target)
         {
             if (target is IXLWorksheet worksheet)
             {
-                ExcuteOnWorksheet(worksheet);
+                ExecuteOnWorksheet(worksheet);
                 return target;
             }
 
             throw new NotImplementedException();
         }
 
-        protected abstract void ExcuteOnWorksheet(IXLWorksheet worksheet);
+        protected abstract void ExecuteOnWorksheet(IXLWorksheet worksheet);
     }
 }

--- a/Excely.ClosedXML/Workflows/XlsxExporterExtension.cs
+++ b/Excely.ClosedXML/Workflows/XlsxExporterExtension.cs
@@ -19,7 +19,7 @@ namespace Excely.Workflows
             tableWriter.ConvertFrom(table);
             foreach (var shaders in exporter.Shaders)
             {
-                worksheet = shaders.Excute(worksheet);
+                worksheet = shaders.Execute(worksheet);
             }
         }
 

--- a/Excely.EPPlus.LGPL/Shaders/CellFittingShader.cs
+++ b/Excely.EPPlus.LGPL/Shaders/CellFittingShader.cs
@@ -7,7 +7,7 @@ namespace Excely.EPPlus.LGPL.Shaders
     /// </summary>
     public class CellFittingShader : XlsxShaderBase
     {
-        protected override void ExcuteOnWorksheet(ExcelWorksheet worksheet)
+        protected override void ExecuteOnWorksheet(ExcelWorksheet worksheet)
         {
             worksheet.Cells.AutoFitColumns();
             worksheet.Cells.Style.WrapText = true;

--- a/Excely.EPPlus.LGPL/Shaders/ErrorMarkShader.cs
+++ b/Excely.EPPlus.LGPL/Shaders/ErrorMarkShader.cs
@@ -36,7 +36,7 @@ namespace Excely.EPPlus.LGPL.Shaders
 			Author = author;
 		}
 
-		protected override void ExcuteOnWorksheet(ExcelWorksheet worksheet)
+		protected override void ExecuteOnWorksheet(ExcelWorksheet worksheet)
 		{
 			foreach (var cellError in CellErrors)
 			{
@@ -45,5 +45,5 @@ namespace Excely.EPPlus.LGPL.Shaders
 				cell.AddComment(cellError.Value, Author);
 			}
 		}
-	}
+        }
 }

--- a/Excely.EPPlus.LGPL/Shaders/SchemaFilterShader.cs
+++ b/Excely.EPPlus.LGPL/Shaders/SchemaFilterShader.cs
@@ -27,7 +27,7 @@ namespace Excely.EPPlus.LGPL.Shaders
             StartCell = startCell;
         }
 
-        protected override void ExcuteOnWorksheet(ExcelWorksheet target)
+        protected override void ExecuteOnWorksheet(ExcelWorksheet target)
         {
             var schemaLength = SchemaLength;
             if (schemaLength == 0)

--- a/Excely.EPPlus.LGPL/Shaders/TableThemeShader.cs
+++ b/Excely.EPPlus.LGPL/Shaders/TableThemeShader.cs
@@ -41,7 +41,7 @@ namespace Excely.EPPlus.LGPL.Shaders
             TableHeight = tableHeight;
         }
 
-        protected override void ExcuteOnWorksheet(ExcelWorksheet worksheet)
+        protected override void ExecuteOnWorksheet(ExcelWorksheet worksheet)
         {
             // 設定標題的背景色和文字色
             var header = worksheet.Cells[StartCell.Row + 1, StartCell.Column + 1, StartCell.Row + SchemaHeight, StartCell.Column + TableWidth];

--- a/Excely.EPPlus.LGPL/Shaders/XlsxShaderBase.cs
+++ b/Excely.EPPlus.LGPL/Shaders/XlsxShaderBase.cs
@@ -8,17 +8,17 @@ namespace Excely.EPPlus.LGPL.Shaders
     /// </summary>
     public abstract class XlsxShaderBase : IShader
     {
-        public T Excute<T>(T target)
+        public T Execute<T>(T target)
         {
             if (target is ExcelWorksheet worksheet)
             {
-                ExcuteOnWorksheet(worksheet);
+                ExecuteOnWorksheet(worksheet);
                 return target;
             }
 
             throw new NotImplementedException();
         }
 
-        protected abstract void ExcuteOnWorksheet(ExcelWorksheet worksheet);
+        protected abstract void ExecuteOnWorksheet(ExcelWorksheet worksheet);
     }
 }

--- a/Excely.EPPlus.LGPL/Workflows/XlsxExporterExtension.cs
+++ b/Excely.EPPlus.LGPL/Workflows/XlsxExporterExtension.cs
@@ -19,7 +19,7 @@ namespace Excely.Workflows
             tableWriter.ConvertFrom(table);
             foreach (var shaders in exporter.Shaders)
             {
-                worksheet = shaders.Excute(worksheet);
+                worksheet = shaders.Execute(worksheet);
             }
         }
 

--- a/Excely/Shaders/IShader.cs
+++ b/Excely/Shaders/IShader.cs
@@ -11,6 +11,6 @@
         /// <param name="target">執行目標</param>
         /// <typeparam name="TOutput">匯出結果的載體</typeparam>
         /// <returns>執行結果</returns>
-        TOutput Excute<TOutput>(TOutput target);
+        TOutput Execute<TOutput>(TOutput target);
     }
 }

--- a/Excely/Workflows/ExcelyExporter.cs
+++ b/Excely/Workflows/ExcelyExporter.cs
@@ -47,7 +47,7 @@ namespace Excely.Workflows
             var result = tableWriter.ConvertFrom(table);
             foreach (var shaders in Shaders)
             {
-                result = shaders.Excute(result);
+                result = shaders.Execute(result);
             }
             return result;
         }
@@ -64,7 +64,7 @@ namespace Excely.Workflows
             var result = tableWriter.ConvertFrom(table);
             foreach (var shaders in Shaders)
             {
-                result = shaders.Excute(result);
+                result = shaders.Execute(result);
             }
             return result;
         }


### PR DESCRIPTION
## Summary
- rename `Excute` methods to `Execute`
- update derived shader classes
- update workflow extensions and exporter to use `Execute`
- fix tab indentation in ErrorMarkShader classes

## Testing
- `dotnet test` *(fails: command not found)*