### PR TITLE
Fix CI .NET version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
     - name: Build
       run: dotnet build --configuration Release
     - name: Test


### PR DESCRIPTION
## Summary
- use setup-dotnet with .NET 6 to match project

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*