### PR TITLE
Fix CSV newline handling and column width calculation

### DIFF
--- a/Excely/ExcelyTable.cs
+++ b/Excely/ExcelyTable.cs
@@ -18,7 +18,7 @@
         /// <summary>
         /// 表格寬度。
         /// </summary>
-        public int MaxColumnCount => Data.OrderBy(x => x.Count).FirstOrDefault()?.Count ?? 0;
+        public int MaxColumnCount => Data.Any() ? Data.Max(x => x.Count) : 0;
 
         public ExcelyTable(IList<IList<object?>> data)
         {

--- a/Excely/TableFactories/CsvStringTableFactory.cs
+++ b/Excely/TableFactories/CsvStringTableFactory.cs
@@ -104,7 +104,7 @@ namespace Excely.TableFactories
                     }
 
                     // 換行
-                    else if (i < sourceData.Length - 2 && sourceData.Substring(i + 1, 2) == "\r\n")
+                    else if (i < sourceData.Length - 1 && sourceData.Substring(i, 2) == "\r\n")
                     {
                         SaveColumn(row, columnBuilder);
                         SaveRow(result, ref row);


### PR DESCRIPTION
## Summary
- correct `MaxColumnCount` so it reports the widest row
- handle `\r\n` properly in CsvStringTableFactory when parsing

## Testing
- `dotnet test` *(fails: `dotnet` not found)*