### PR TITLE
Fix workbook disposal and importer test

### DIFF
--- a/Excely.ClosedXML.UnitTests/XlsxImporterTests.cs
+++ b/Excely.ClosedXML.UnitTests/XlsxImporterTests.cs
@@ -1,0 +1,32 @@
+using ClosedXML.Excel;
+using Excely.Workflows;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Excely.ClosedXML.UnitTests
+{
+    [TestClass]
+    public class XlsxImporterTests
+    {
+        [TestMethod]
+        public void Importer_ShouldReadFileMultipleTimesWithoutLocking()
+        {
+            // Arrange
+            var tempFile = Path.GetTempFileName();
+            using (var workbook = new XLWorkbook())
+            {
+                var ws = workbook.AddWorksheet("sheet1");
+                ws.Cell(1, 1).Value = "Name";
+                ws.Cell(1, 2).Value = "Value";
+                ws.Cell(2, 1).Value = "A";
+                ws.Cell(2, 2).Value = 1;
+                workbook.SaveAs(tempFile);
+            }
+
+            var importer = new XlsxImporter();
+
+            // Act & Assert - should not throw because of file locking
+            importer.ToDictionaryList(tempFile).ToList();
+            importer.ToDictionaryList(tempFile).ToList();
+        }
+    }
+}

--- a/Excely.ClosedXML/Workflows/XlsxImporter.cs
+++ b/Excely.ClosedXML/Workflows/XlsxImporter.cs
@@ -31,7 +31,7 @@ namespace Excely.Workflows
 
 		protected override IXLWorksheet GetDataSource(string filePath)
 		{
-			var workbook = new XLWorkbook(filePath);
+			using var workbook = new XLWorkbook(filePath);
 			return workbook.Worksheet(1);
 		}
 	}


### PR DESCRIPTION
## Summary
- ensure `XlsxImporter.GetDataSource` disposes workbook using `using var`
- add regression test verifying repeated reads don't lock the file
- fix indentation of `GetDataSource`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*